### PR TITLE
Run cargo fmt on source

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub enum TorrentSearchError {
     /// The seeds regex failed
     SeedsNotFound,
     /// The leeches regex failed
-    LeechesNotFound
+    LeechesNotFound,
 }
 
 ///This necessary to make using minreq::get possible
@@ -73,7 +73,6 @@ pub struct TorrentSearchResult {
     ///The magnet url as a string (considered releasing it as a Magnet struct, but decided against it
     ///It's wrapped in a result since the torrent search can work, but accessing a magnet can fail
     pub magnet: Result<String, TorrentSearchError>,
-
 }
 
 ///The function takes a search string, then uses web scraping using regex to find the various parts
@@ -85,41 +84,44 @@ pub async fn search_l337x(search: String) -> Result<Vec<TorrentSearchResult>, To
         let torrents = find_torrents(get_l337x(search).await?);
 
         match torrents {
-            Ok(torrents) =>
-                {
-                    for (i, val) in torrents.0.iter().enumerate() {
-                        let (seeder_info, leeches_info) = find_peer_info(val).await?;
+            Ok(torrents) => {
+                for (i, val) in torrents.0.iter().enumerate() {
+                    let (seeder_info, leeches_info) = find_peer_info(val).await?;
 
-                        search_results.push(
-                            TorrentSearchResult {
-                                name: String::from(&torrents.1[i]),
-                                magnet: match find_magnet(val).await {
-                                    Ok(m) => Ok(m),
-                                    Err(e) => Err(e),
-                                },
-                                seeders: seeder_info,
-                                leeches: leeches_info,
-                            }
-                        );
-                    }
+                    search_results.push(TorrentSearchResult {
+                        name: String::from(&torrents.1[i]),
+                        magnet: match find_magnet(val).await {
+                            Ok(m) => Ok(m),
+                            Err(e) => Err(e),
+                        },
+                        seeders: seeder_info,
+                        leeches: leeches_info,
+                    });
+                }
 
-                    Ok(search_results)
-                },
+                Ok(search_results)
+            }
 
-            Err(e) => {
-                Err(e)
-            },
+            Err(e) => Err(e),
         }
     } else {
         Err(TorrentSearchError::SearchTooShort)
     }
-
 }
 
 async fn get_l337x(search: String) -> Result<String, reqwest::Error> {
     //Remove all slashes from searches, as 1337x searches do not allow them
-    let page = reqwest::get( &format!("https://1337x.to/search/{}/1/", search.replace("/", "+").replace("%2F", "+").replace("%2f", "+"))).await?.text().await?;
-    
+    let page = reqwest::get(&format!(
+        "https://1337x.to/search/{}/1/",
+        search
+            .replace("/", "+")
+            .replace("%2F", "+")
+            .replace("%2f", "+")
+    ))
+    .await?
+    .text()
+    .await?;
+
     Ok(page)
 }
 
@@ -128,15 +130,20 @@ fn find_torrents(page: String) -> Result<(Vec<String>, Vec<String>), TorrentSear
         static ref TORRENT_RES_RE: Regex = Regex::new(TORRENT_RES_RE_STR).unwrap();
     }
 
-
     //Index 0 of the tuple has the torrent url, index 1 has its name
     let responses = {
         let mut responses: (Vec<String>, Vec<String>) = (Vec::new(), Vec::new());
 
         for result in TORRENT_RES_RE.captures_iter(&page) {
             //Gotta add a slash at the end of the urls, or else it's invalid and will give a 404 if you visit it on 1337x
-            responses.0.push(format!("{}{}", result.get(1).map_or("", |m| m.as_str()).to_string(), "/"));
-            responses.1.push(result.get(2).map_or("", |m| m.as_str()).to_string());
+            responses.0.push(format!(
+                "{}{}",
+                result.get(1).map_or("", |m| m.as_str()).to_string(),
+                "/"
+            ));
+            responses
+                .1
+                .push(result.get(2).map_or("", |m| m.as_str()).to_string());
         }
 
         responses
@@ -157,7 +164,10 @@ async fn find_magnet(url: &String) -> Result<String, TorrentSearchError> {
         static ref MAGNET_RE: Regex = Regex::new(MAGNET_RE_STR).unwrap();
     }
 
-    let page = reqwest::get( &format!("https://1337x.to{}", url) ).await?.text().await?;
+    let page = reqwest::get(&format!("https://1337x.to{}", url))
+        .await?
+        .text()
+        .await?;
 
     match MAGNET_RE.captures(&page) {
         Some(captures) => Ok(captures.get(0).map_or("", |m| m.as_str()).to_string()),
@@ -165,24 +175,42 @@ async fn find_magnet(url: &String) -> Result<String, TorrentSearchError> {
     }
 }
 
-async fn find_peer_info(url: &String) -> Result<(Result<usize, TorrentSearchError>, Result<usize, TorrentSearchError>), TorrentSearchError> {
+async fn find_peer_info(
+    url: &String,
+) -> Result<
+    (
+        Result<usize, TorrentSearchError>,
+        Result<usize, TorrentSearchError>,
+    ),
+    TorrentSearchError,
+> {
     lazy_static! {
         static ref SEEDS_RE: Regex = Regex::new(SEEDS_RE_STR).unwrap();
         static ref LEECHES_RE: Regex = Regex::new(LEECHES_RE_STR).unwrap();
     }
 
-    let page = reqwest::get( &format!("https://1337x.to{}", url)).await?.text().await?;
+    let page = reqwest::get(&format!("https://1337x.to{}", url))
+        .await?
+        .text()
+        .await?;
 
     let seeds = match SEEDS_RE.captures(&page) {
-        Some(captures) => Ok(captures.get(1).map_or("", |m| m.as_str()).parse::<usize>().unwrap()),
+        Some(captures) => Ok(captures
+            .get(1)
+            .map_or("", |m| m.as_str())
+            .parse::<usize>()
+            .unwrap()),
         None => Err(TorrentSearchError::SeedsNotFound),
     };
 
     let leeches = match LEECHES_RE.captures(&page) {
-        Some(captures) => Ok(captures.get(1).map_or("", |m| m.as_str()).parse::<usize>().unwrap()),
+        Some(captures) => Ok(captures
+            .get(1)
+            .map_or("", |m| m.as_str())
+            .parse::<usize>()
+            .unwrap()),
         None => Err(TorrentSearchError::LeechesNotFound),
     };
 
     Ok((seeds, leeches))
-
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,19 +1,23 @@
 #[cfg(test)]
 mod tests {
     extern crate torrent_search;
-    use torrent_search::{search_l337x, TorrentSearchError};
     use tokio::join;
+    use torrent_search::{search_l337x, TorrentSearchError};
 
     #[tokio::test]
     async fn search_test() {
-        let deb_search_fut = search_l337x("Debian-8-7-1-Jessie-KDE-x32-i386-CD1-ISO-Uzerus".to_string());
-        
+        let deb_search_fut =
+            search_l337x("Debian-8-7-1-Jessie-KDE-x32-i386-CD1-ISO-Uzerus".to_string());
+
         let arch_search_fut = search_l337x("Arch-Linux-2014-10-10-x86-x64".to_string());
-        
-        let sintel_search_fut = search_l337x("Sintel 4K UHD ENG FLAC ITA ENG Sub DMRip 1744p X264 ZMachine".to_string());
-        
-        let (deb_res, arch_res, sintel_res) = join!(deb_search_fut, arch_search_fut, sintel_search_fut);
-    
+
+        let sintel_search_fut = search_l337x(
+            "Sintel 4K UHD ENG FLAC ITA ENG Sub DMRip 1744p X264 ZMachine".to_string(),
+        );
+
+        let (deb_res, arch_res, sintel_res) =
+            join!(deb_search_fut, arch_search_fut, sintel_search_fut);
+
         assert_eq!(deb_res.unwrap()[0].magnet, Ok("magnet:?xt=urn:btih:9EB579CA38807332ECA53358E5E014CAD70C1358&dn=Debian+8.7.1+%5BJessie%5D%5BKDE%5D%5Bx32%5D%5Bi386%5D%5BCD1%5D%5BISO%5D%5BUzerus%5D&tr=udp%3A%2F%2Ftracker.zer0day.to%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fcoppersurfer.tk%3A6969%2Fannounce".to_string()));
         assert_eq!(arch_res.unwrap()[0].magnet, Ok("magnet:?xt=urn:btih:FF71F60D489A634C0E55972A60A50FE7B13A4A4F&dn=Arch+Linux+-+2014.10.10+-+%28x86%2Fx64%29&tr=http%3A%2F%2Ftracker.archlinux.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.zer0day.to%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fcoppersurfer.tk%3A6969%2Fannounce".to_string()));
         assert_eq!(sintel_res.unwrap()[0].magnet, Ok("magnet:?xt=urn:btih:64877B5490208C3015C0F5121287949D62622E54&dn=Sintel+4K+UHD+ENG+FLAC+ITA+ENG+Sub+DMRip+1744p+X264+ZMachine&tr=http%3A%2F%2Ftracker.tntvillage.scambioetico.org%3A2710%2Fannounce&tr=udp%3A%2F%2Ftracker.tntvillage.scambioetico.org%3A2710%2Fannounce&tr=udp%3A%2F%2Ftracker.yify-torrents.com%3A80%2Fannounce&tr=udp%3A%2F%2F10.rarbg.me%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.prq.to%2Fannounce&tr=udp%3A%2F%2F12.rarbg.me%3A80%2Fannounce&tr=udp%3A%2F%2F9.rarbg.com%3A2710%2Fannounce&tr=udp%3A%2F%2Ftracker.token.ro%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.istole.it%3A80%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.com%3A1337%2Fannounce&tr=udp%3A%2F%2Fexodus.desync.com%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.publicbt.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.zer0day.to%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fcoppersurfer.tk%3A6969%2Fannounce".to_string()));
@@ -21,10 +25,22 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_search_test() {
-        assert_eq!(search_l337x("dsfadsmfoaisdmvapedoejdapoae".to_string()).await, Err(TorrentSearchError::NoSearchResults));
-        assert_eq!(search_l337x("iqowejfopqewfcosidmfopasdmfpaoeiwmf".to_string()).await, Err(TorrentSearchError::NoSearchResults));
+        assert_eq!(
+            search_l337x("dsfadsmfoaisdmvapedoejdapoae".to_string()).await,
+            Err(TorrentSearchError::NoSearchResults)
+        );
+        assert_eq!(
+            search_l337x("iqowejfopqewfcosidmfopasdmfpaoeiwmf".to_string()).await,
+            Err(TorrentSearchError::NoSearchResults)
+        );
         //L337X also doesn't allow searches shorter than 3 characters
-        assert_eq!(search_l337x("jj".to_string()).await, Err(TorrentSearchError::SearchTooShort));
-        assert_eq!(search_l337x("hi".to_string()).await, Err(TorrentSearchError::SearchTooShort));
+        assert_eq!(
+            search_l337x("jj".to_string()).await,
+            Err(TorrentSearchError::SearchTooShort)
+        );
+        assert_eq!(
+            search_l337x("hi".to_string()).await,
+            Err(TorrentSearchError::SearchTooShort)
+        );
     }
 }


### PR DESCRIPTION
I configured my editor to run cargo fmt every time I save the file, so it's a bit annoying if the source isn't formatted accordingly. But I'm not sure if you actually like to format your source with cargo fmt.